### PR TITLE
Update meetup-update skill with the real booking workflow

### DIFF
--- a/.claude/skills/meetup-update/SKILL.md
+++ b/.claude/skills/meetup-update/SKILL.md
@@ -5,11 +5,12 @@ description: >-
   "do the monthly update", "archive the meetup", "add the next meetup",
   "update for [month] meetup", "set up the new meetup", "prepare next
   month's meetup", provides speaker submission data for an upcoming
-  meetup, or provides a meetup.com event URL. Also available via the
-  `/update-meetup` command with a meetup.com URL. Guides the complete
-  monthly transition workflow for the PyTexas Meetup website including
-  archiving the current meetup, adding the new speaker, and updating
-  the homepage.
+  meetup, provides a meetup.com event URL, or asks to pull a speaker's
+  submission from the Google Form / CFP responses spreadsheet. Also
+  available via the `/update-meetup` command with a meetup.com URL.
+  Guides the complete monthly transition workflow for the PyTexas
+  Meetup website including archiving the current meetup, adding the
+  new speaker, and updating the homepage.
 ---
 
 # Monthly Meetup Update
@@ -31,16 +32,29 @@ Additionally, one manual step is flagged for the user:
 
 ## Input Data
 
-Input can come from two sources:
+Input can come from three sources:
 
-### Option A: Meetup.com Event URL
+### Option A: CFP Responses Spreadsheet (Google Drive)
+
+Speaker submissions land in the "PyTexas Meetup CFP (Responses)" Google Sheet.
+Search Drive for it by title; there is an older sheet with the same name from 2024, so pick the one with recent timestamps.
+Relevant columns: Name, About you (bio), Speaker Photo, Presentation Title, Presentation Description, Estimated Presentation Length, Acked, Comments.
+
+- Acked TRUE means Mason has already contacted the speaker.
+- Acked FALSE with a dismissive comment (e.g. "Not enough to go off of") means the submission was passed on; do not book or contact without asking.
+- Early rows are form tests from Josh Schneider and Mason; ignore them.
+- A speaker may submit more than once; the latest row usually supersedes earlier ones, but confirm which talk they actually gave or will give.
+
+The July lightning talks have their own sheet (e.g. "PyTexas July 2026 Lightning Talks (Responses)") with a Speaker Order tab.
+
+### Option B: Meetup.com Event URL
 
 When given a meetup.com URL (or invoked via `/update-meetup <url>`), use WebFetch to retrieve
 the event page and extract: event date, talk title, speaker name, talk description, speaker bio,
 and speaker headshot URL. Present the extracted data to the user for confirmation before proceeding.
 If any required fields are missing from the page, ask the user to provide them.
 
-### Option B: Raw Speaker Submission Data
+### Option C: Raw Speaker Submission Data
 
 The user provides speaker submission data directly containing:
 
@@ -50,7 +64,23 @@ The user provides speaker submission data directly containing:
 - Headshot link (usually Google Drive)
 - Speaker bio
 
+## Confirming the Speaker's Date
+
+The CFP submission does not carry a meetup date. Never assume the speaker is booked for the next open month.
+
+Mason emails each accepted speaker (subject "Speak at PyTexas Meetup") offering the open first-Tuesday dates and asking them to pick two; the booked date is settled in that thread.
+Before putting a speaker on the homepage, search Gmail for the thread and confirm which date was locked in.
+If the thread is ambiguous or unanswered, ask Mason instead of guessing.
+
+Also check the thread for corrections to the form data, such as a different preferred contact email.
+
 ## Workflow
+
+### Step 0: Sync With Main
+
+The site may be several months behind, and main may have moved since the local checkout.
+Fetch origin, start a feature branch from up-to-date main, and check which meetups are already archived in `docs/past_meetups/posts/` before deciding what to archive.
+Never commit to main; Mason merges PRs himself.
 
 ### Step 1: Archive the Current Meetup
 
@@ -76,7 +106,7 @@ Edit `docs/index.md` to replace the current meetup section with the new month's 
 
 - Update the heading to the new month and date (meetups are the **first Tuesday** of the month)
 - Replace the talk title, speaker name, and description
-- The RSVP link is always `https://pytexas.org/meetup/join` — no per-event update needed
+- The RSVP link is always `https://pytexas.org/meetup/join`; no per-event update needed
 - Update the headshot image path and speaker bio
 
 See `references/file-formats.md` for the exact markdown format.
@@ -86,6 +116,10 @@ See `references/file-formats.md` for the exact markdown format.
 After completing the automated changes, remind the user of one manual task:
 
 1. **Speaker headshot**: Download from the provided link and save to `docs/assets/images/<name>.<ext>`
+
+The Speaker Photo field sometimes says to email the speaker for the file instead of giving a URL.
+In that case Mason requests it over email; the site references the image path before the file exists, so `mkdocs build --strict` (and CI) fails until the headshot lands.
+If the PR must wait on the headshot or an earlier month's speaker, mark it as a draft.
 
 ## Determining the Meetup Date
 
@@ -119,8 +153,29 @@ Machine Learning, Cloud, Automation.
 If there is no meetup for a given month (e.g., conference month, holiday skip), ask the user
 for guidance on what to display on the homepage instead of the typical upcoming meetup section.
 
+### July Lightning Talks
+
+July is the annual "Summer of Lightning Talks" meetup; there is no single speaker.
+
+- The homepage section has no speaker or headshot; it links the RSVP page and the talk sign-up form.
+- The archive post is titled "Summer of Lightning Talks", authored by `masonegger`, and lists each speaker and talk title as bullets after the `<!-- more -->` tag.
+  Match the prior year's post (e.g. `docs/past_meetups/posts/2025-07-01.md`).
+- Pull the speaker list and order from that year's lightning talks response sheet in Drive.
+
+### Speaker Booked for a Later Month
+
+A speaker may lock in a month other than the next open one, leaving nearer months without a speaker.
+Put the speaker in their confirmed month, ask Mason what to do about the open months, and mark the PR as a draft until they are filled.
+
+## Speaker Outreach
+
+When months need speakers, un-acked CFP submissions are the candidate pool.
+Mason sends each candidate the standard offer email; draft (never send) these in Gmail using `references/outreach-email.md`, listing only the still-open dates.
+After drafting, remind Mason that Gmail rewrites bare URLs in API-created drafts into `google.com/url` redirect wrappers, so he should check the Discord link in the compose window before sending.
+
 ## Additional Resources
 
 ### Reference Files
 
 - **`references/file-formats.md`** - Exact file format templates for all three files that get modified
+- **`references/outreach-email.md`** - Template for the speaker date-offer email

--- a/.claude/skills/meetup-update/SKILL.md
+++ b/.claude/skills/meetup-update/SKILL.md
@@ -2,39 +2,43 @@
 name: Monthly Meetup Update
 description: >-
   This skill should be used when the user asks to "update the meetup",
-  "do the monthly update", "archive the meetup", "add the next meetup",
-  "update for [month] meetup", "set up the new meetup", "prepare next
-  month's meetup", provides speaker submission data for an upcoming
-  meetup, provides a meetup.com event URL, or asks to pull a speaker's
-  submission from the Google Form / CFP responses spreadsheet. Also
-  available via the `/update-meetup` command with a meetup.com URL.
-  Guides the complete monthly transition workflow for the PyTexas
-  Meetup website including archiving the current meetup, adding the
-  new speaker, and updating the homepage.
+  "do the monthly update", "schedule the monthly meetup", "archive the
+  meetup", "add the next meetup", "update for [month] meetup", "set up
+  the new meetup", "prepare next month's meetup", provides speaker
+  submission data for an upcoming meetup, provides a meetup.com event
+  URL, or asks to pull a speaker's submission from the Google Form /
+  CFP responses spreadsheet. Also available via the `/update-meetup`
+  command with a meetup.com URL. Runs the full monthly meetup setup:
+  pulling the speaker from the CFP sheet, updating the website,
+  creating the Canva promo card, drafting the social media email, and
+  flagging the event listings that stay manual.
 ---
 
 # Monthly Meetup Update
 
-This skill handles the recurring monthly workflow for transitioning the PyTexas Meetup website
-from the current month's meetup to the next month's meetup.
+This skill runs the full monthly setup for the next PyTexas Meetup.
+It mirrors the recurring Todoist task "Schedule Monthly Meetup" (every 2nd Wednesday, in the PyTexas project), which is the checklist of record.
 
 ## Overview
 
-Each month, the website needs three updates:
+The Todoist subtasks and how this skill handles each:
 
-1. **Archive** the current meetup as a past meetup blog post
-2. **Add** the new speaker to the authors file
-3. **Update** the homepage with the upcoming meetup details
+1. **Update Meetup Website** - automated here: archive the held meetup, add the speaker to authors, update the homepage, open a PR
+2. **Create Canva Card** - attempted via the Canva MCP; flagged with the design's edit link if editing fails
+3. **Send Social Media Assets to Kassandra** - Gmail draft created for Mason to review and send
+4. **Create Discord Event** - manual, flagged at the end
+5. **Create Network Event on Meetup** - manual, flagged at the end
+6. **Create Event on Non-network meetups (MKE)** - manual, flagged at the end
 
-Additionally, one manual step is flagged for the user:
-
-- Download and save the speaker's headshot image
+Speaker data always comes from the Google MCP first (Drive for the CFP sheet, Gmail for the booked date).
+If Todoist is connected, re-read the subtasks of "Schedule Monthly Meetup" at the start in case the checklist has changed, and follow the live list over the one above.
 
 ## Input Data
 
-Input can come from three sources:
+Always pull from the Google MCP first.
+The other input options are fallbacks for when Drive is unavailable or the user hands over data directly.
 
-### Option A: CFP Responses Spreadsheet (Google Drive)
+### Primary Source: CFP Responses Spreadsheet (Google Drive)
 
 Speaker submissions land in the "PyTexas Meetup CFP (Responses)" Google Sheet.
 Search Drive for it by title; there is an older sheet with the same name from 2024, so pick the one with recent timestamps.
@@ -47,14 +51,14 @@ Relevant columns: Name, About you (bio), Speaker Photo, Presentation Title, Pres
 
 The July lightning talks have their own sheet (e.g. "PyTexas July 2026 Lightning Talks (Responses)") with a Speaker Order tab.
 
-### Option B: Meetup.com Event URL
+### Fallback A: Meetup.com Event URL
 
 When given a meetup.com URL (or invoked via `/update-meetup <url>`), use WebFetch to retrieve
 the event page and extract: event date, talk title, speaker name, talk description, speaker bio,
 and speaker headshot URL. Present the extracted data to the user for confirmation before proceeding.
 If any required fields are missing from the page, ask the user to provide them.
 
-### Option C: Raw Speaker Submission Data
+### Fallback B: Raw Speaker Submission Data
 
 The user provides speaker submission data directly containing:
 
@@ -76,13 +80,19 @@ Also check the thread for corrections to the form data, such as a different pref
 
 ## Workflow
 
-### Step 0: Sync With Main
+### Step 1: Pull Speaker Data From Google
+
+This is always the first step.
+Find the booked speaker's row in the CFP responses sheet (see Primary Source above), then confirm their locked-in date from the Gmail thread (see Confirming the Speaker's Date).
+Carry forward the talk title, description, bio, headshot source, and any corrected contact email.
+
+### Step 2: Sync With Main
 
 The site may be several months behind, and main may have moved since the local checkout.
 Fetch origin, start a feature branch from up-to-date main, and check which meetups are already archived in `docs/past_meetups/posts/` before deciding what to archive.
 Never commit to main; Mason merges PRs himself.
 
-### Step 1: Archive the Current Meetup
+### Step 3: Archive the Current Meetup
 
 Create a new file at `docs/past_meetups/posts/YYYY-MM-DD.md` where the date is the date
 of the meetup being archived (the one currently on the homepage).
@@ -90,7 +100,7 @@ of the meetup being archived (the one currently on the homepage).
 Copy the talk title, description, speaker bio, and headshot reference from `docs/index.md`
 into the new post file. Follow the format documented in `references/file-formats.md`.
 
-### Step 2: Add the New Speaker to Authors
+### Step 4: Add the New Speaker to Authors
 
 Edit `docs/past_meetups/.authors.yml` to add a new entry for the incoming speaker.
 
@@ -100,7 +110,7 @@ Edit `docs/past_meetups/.authors.yml` to add a new entry for the incoming speake
 
 See `references/file-formats.md` for the exact YAML format.
 
-### Step 3: Update the Homepage
+### Step 5: Update the Homepage
 
 Edit `docs/index.md` to replace the current meetup section with the new month's details.
 
@@ -111,15 +121,44 @@ Edit `docs/index.md` to replace the current meetup section with the new month's 
 
 See `references/file-formats.md` for the exact markdown format.
 
-### Step 4: Flag Manual Steps
+### Step 6: Flag the Headshot If Missing
 
-After completing the automated changes, remind the user of one manual task:
+After completing the website changes, remind the user of one manual task:
 
 1. **Speaker headshot**: Download from the provided link and save to `docs/assets/images/<name>.<ext>`
 
 The Speaker Photo field sometimes says to email the speaker for the file instead of giving a URL.
 In that case Mason requests it over email; the site references the image path before the file exists, so `mkdocs build --strict` (and CI) fails until the headshot lands.
 If the PR must wait on the headshot or an earlier month's speaker, mark it as a draft.
+
+### Step 7: Create the Canva Card
+
+The monthly promo cards live in a single Canva design per year named "<year> Meetup Banners", one page per month.
+Use the Canva MCP:
+
+1. Find the current year's design with `search-designs` (query "<year> Meetup Banners"). At year boundaries the design may not exist yet; ask Mason before creating one.
+2. Look at the most recent month's page to match its layout.
+3. Add the new month's page with the talk title, speaker name, date, and headshot.
+4. If the editing tools cannot make the change cleanly, stop and give Mason the design's edit URL with a list of the text to place; do not leave a half-edited page.
+
+### Step 8: Draft the Social Media Email to Kassandra
+
+Kassandra Keeton (kassandra@pytexas.org) posts the social media promotion.
+Create a Gmail draft (never send) addressed to her with the month's meetup details (date, talk title, speaker) and a link to the Canva design or the exported card.
+If the card could not be created, say so in the draft and link the design for her to finish.
+
+### Step 9: Flag the Event Listings
+
+These have no MCP access and stay manual. List them for Mason at the end of the run:
+
+1. **Create Discord Event** in the PyTexas Discord
+2. **Create Network Event on Meetup** (meetup.com)
+3. **Create Event on Non-network meetups** (MKE)
+
+### Step 10: Report Against the Todoist Checklist
+
+Finish by reporting each "Schedule Monthly Meetup" subtask as done, drafted awaiting Mason's review, or still manual.
+Do not check off subtasks in Todoist without Mason's confirmation; the website subtask in particular is not done until the PR merges and the headshot lands.
 
 ## Determining the Meetup Date
 

--- a/.claude/skills/meetup-update/SKILL.md
+++ b/.claude/skills/meetup-update/SKILL.md
@@ -10,8 +10,9 @@ description: >-
   CFP responses spreadsheet. Also available via the `/update-meetup`
   command with a meetup.com URL. Runs the full monthly meetup setup:
   pulling the speaker from the CFP sheet, updating the website,
-  creating the Canva promo card, drafting the social media email, and
-  flagging the event listings that stay manual.
+  creating the Drive month folder with the run of show and attendance
+  form, creating the Canva promo card, drafting the social media
+  email, and flagging the event listings that stay manual.
 ---
 
 # Monthly Meetup Update
@@ -30,8 +31,17 @@ The Todoist subtasks and how this skill handles each:
 5. **Create Network Event on Meetup** - manual, flagged at the end
 6. **Create Event on Non-network meetups (MKE)** - manual, flagged at the end
 
+Beyond the Todoist list, the skill also creates the meetup-night materials in Drive: the month folder, the run of show doc, and the attendance form.
+
 Speaker data always comes from the Google MCP first (Drive for the CFP sheet, Gmail for the booked date).
 If Todoist is connected, re-read the subtasks of "Schedule Monthly Meetup" at the start in case the checklist has changed, and follow the live list over the one above.
+
+## Template Policy
+
+Every artifact this skill produces is template-driven.
+Use the reference template verbatim and fill only the marked slots; never rewrite, paraphrase, or improvise the template prose.
+The outreach email, run of show, attendance form, Canva card, and Kassandra email each have a reference file listed at the bottom.
+If Mason changes an artifact's wording, update its template file so the next run produces the new exact version.
 
 ## Input Data
 
@@ -131,23 +141,24 @@ The Speaker Photo field sometimes says to email the speaker for the file instead
 In that case Mason requests it over email; the site references the image path before the file exists, so `mkdocs build --strict` (and CI) fails until the headshot lands.
 If the PR must wait on the headshot or an earlier month's speaker, mark it as a draft.
 
-### Step 7: Create the Canva Card
+### Step 7: Create the Drive Artifacts
 
-The monthly promo cards live in a single Canva design per year named "<year> Meetup Banners", one page per month.
-Use the Canva MCP:
+Create the month folder, run of show doc, and attendance form in Google Drive.
+Follow `references/drive-artifacts.md` for the folder layout, template locations, and copy procedure, and `references/run-of-show.md` for the fill-in content.
+Fill what is known at setup time; roles, announcements, and the local meetups table stay as placeholders until meetup night.
 
-1. Find the current year's design with `search-designs` (query "<year> Meetup Banners"). At year boundaries the design may not exist yet; ask Mason before creating one.
-2. Look at the most recent month's page to match its layout.
-3. Add the new month's page with the talk title, speaker name, date, and headshot.
-4. If the editing tools cannot make the change cleanly, stop and give Mason the design's edit URL with a list of the text to place; do not leave a half-edited page.
+### Step 8: Create the Canva Card
 
-### Step 8: Draft the Social Media Email to Kassandra
+The promo cards live in one Canva deck per season (September through August), one page per month.
+Follow `references/canva-cards.md` for picking or creating the right deck and adding the page.
+If the editing tools cannot make the change cleanly, stop and give Mason the design's edit URL with the exact text to place; do not leave a half-edited page.
+
+### Step 9: Draft the Social Media Email to Kassandra
 
 Kassandra Keeton (kassandra@pytexas.org) posts the social media promotion.
-Create a Gmail draft (never send) addressed to her with the month's meetup details (date, talk title, speaker) and a link to the Canva design or the exported card.
-If the card could not be created, say so in the draft and link the design for her to finish.
+Create a Gmail draft (never send) from the template in `references/kassandra-email.md`, filling only the marked slots.
 
-### Step 9: Flag the Event Listings
+### Step 10: Flag the Event Listings
 
 These have no MCP access and stay manual. List them for Mason at the end of the run:
 
@@ -155,7 +166,10 @@ These have no MCP access and stay manual. List them for Mason at the end of the 
 2. **Create Network Event on Meetup** (meetup.com)
 3. **Create Event on Non-network meetups** (MKE)
 
-### Step 10: Report Against the Todoist Checklist
+Meetup.com event creation is automatable through their GraphQL API once Mason obtains OAuth credentials (requested through the Meetup Pro admin account).
+Until those credentials exist and an integration is set up, treat it as manual; when they do, codify it here.
+
+### Step 11: Report Against the Todoist Checklist
 
 Finish by reporting each "Schedule Monthly Meetup" subtask as done, drafted awaiting Mason's review, or still manual.
 Do not check off subtasks in Todoist without Mason's confirmation; the website subtask in particular is not done until the PR merges and the headshot lands.
@@ -216,5 +230,9 @@ After drafting, remind Mason that Gmail rewrites bare URLs in API-created drafts
 
 ### Reference Files
 
-- **`references/file-formats.md`** - Exact file format templates for all three files that get modified
-- **`references/outreach-email.md`** - Template for the speaker date-offer email
+- **`references/file-formats.md`** - Exact file format templates for the three website files that get modified
+- **`references/outreach-email.md`** - Exact template for the speaker date-offer email
+- **`references/drive-artifacts.md`** - Drive folder layout and procedure for the run of show and attendance form
+- **`references/run-of-show.md`** - Exact fill-in template for the run of show doc
+- **`references/canva-cards.md`** - Canva season deck rules, naming, and card procedure
+- **`references/kassandra-email.md`** - Template for the social media assets email (proposed, pending Mason's approval)

--- a/.claude/skills/meetup-update/references/canva-cards.md
+++ b/.claude/skills/meetup-update/references/canva-cards.md
@@ -1,0 +1,29 @@
+# Canva Card Decks: Seasons and Naming
+
+The monthly promo cards live in one Canva design per meetup season, one page per month.
+
+## Season Rules
+
+- A season runs September through August, matching the meetup's September 2023 launch (first archived post: `docs/past_meetups/posts/2023-09-11.md`).
+- The deck is named "<YYYY> Meetup Banners" where YYYY is the calendar year of the season's ending August.
+  A season's deck is created in the August or September that opens it.
+
+## Deck History
+
+- "2024 Meetup Banners": Season 1, September 2023 through August 2024
+- "2025 Meetup Banners": Season 2, September 2024 through August 2025
+- "2026 Meetup Banners": Season 3, September 2025 through August 2026
+- "2027 Meetup Banners": Season 4, September 2026 through August 2027 (starts at the three-year anniversary)
+
+## Picking the Deck for a Meetup
+
+1. Meetup in September through December of year N: deck "<N+1> Meetup Banners".
+2. Meetup in January through August of year N: deck "<N> Meetup Banners".
+3. If the deck does not exist yet (first card of a new season), ask Mason before creating it; he may want to set the season's look himself.
+
+## Adding a Month's Card
+
+1. Find the deck with the Canva MCP (`search-designs`, query "<YYYY> Meetup Banners").
+2. Match the layout of the most recent page.
+3. Fill in the talk title, speaker name, meetup date, and headshot.
+4. If the editing tools cannot make the change cleanly, stop and give Mason the design's edit URL plus the exact text to place; never leave a half-edited page.

--- a/.claude/skills/meetup-update/references/canva-cards.md
+++ b/.claude/skills/meetup-update/references/canva-cards.md
@@ -24,6 +24,16 @@ The monthly promo cards live in one Canva design per meetup season, one page per
 ## Adding a Month's Card
 
 1. Find the deck with the Canva MCP (`search-designs`, query "<YYYY> Meetup Banners").
-2. Match the layout of the most recent page.
-3. Fill in the talk title, speaker name, meetup date, and headshot.
+2. Identify the most recent month's page by reading the page contents (the date text element), not by page position; deck pages are not reliably in chronological order.
+3. Copy that page as the base and fill in the talk title, speaker name, meetup date, speaker role line, and headshot.
 4. If the editing tools cannot make the change cleanly, stop and give Mason the design's edit URL plus the exact text to place; never leave a half-edited page.
+
+## Mechanics That Are Known to Work
+
+Verified end to end on 2026-07-22 with a test card:
+
+- `copy-design` with `page_numbers` copies a single page into a new design.
+- `upload-asset-from-url` imports the headshot, but needs a direct URL that returns HTTP 200; resolve redirects first (e.g. `https://github.com/<user>.png` redirects to `avatars.githubusercontent.com`, which works).
+- `replace_text` on the talk title, date, and role elements plus `update_fill` on the editable circular photo element updates the card; commit the transaction to save.
+
+The card layout slots: "Monthly Meetup" heading (fixed), talk title, date ("DD Month YYYY"), time ("8:00 - 9:00pm CST", fixed), "PyTexas Discord Server" (fixed), speaker name, speaker role line, circular headshot, RSVP URL (fixed).

--- a/.claude/skills/meetup-update/references/canva-cards.md
+++ b/.claude/skills/meetup-update/references/canva-cards.md
@@ -23,17 +23,19 @@ The monthly promo cards live in one Canva design per meetup season, one page per
 
 ## Adding a Month's Card
 
+Deck pages run newest first: the new month's card always goes in as page 1.
+Verify by reading the date text on page 1 before assuming.
+
+The workflow, verified end to end on the real deck on 2026-07-22:
+
 1. Find the deck with the Canva MCP (`search-designs`, query "<YYYY> Meetup Banners").
-2. Identify the most recent month's page by reading the page contents (the date text element), not by page position; deck pages are not reliably in chronological order.
-3. Copy that page as the base and fill in the talk title, speaker name, meetup date, speaker role line, and headshot.
-4. If the editing tools cannot make the change cleanly, stop and give Mason the design's edit URL plus the exact text to place; never leave a half-edited page.
-
-## Mechanics That Are Known to Work
-
-Verified end to end on 2026-07-22 with a test card:
-
-- `copy-design` with `page_numbers` copies a single page into a new design.
-- `upload-asset-from-url` imports the headshot, but needs a direct URL that returns HTTP 200; resolve redirects first (e.g. `https://github.com/<user>.png` redirects to `avatars.githubusercontent.com`, which works).
-- `replace_text` on the talk title, date, and role elements plus `update_fill` on the editable circular photo element updates the card; commit the transaction to save.
+2. Find the newest single-speaker page (usually page 1, or page 2 when page 1 is the July lightning talks card, which has no headshot slot).
+3. Upload the speaker headshot with `upload-asset-from-url`. The URL must return HTTP 200 directly; resolve redirects first (e.g. `https://github.com/<user>.png` redirects to `avatars.githubusercontent.com`, which works).
+4. Duplicate that page to the top of the same deck: `merge-designs` with `modify_existing_design`, one `insert_pages` operation sourcing the deck itself and `after_page_number: 0`. Get Mason's go-ahead before this call; it modifies the real deck.
+5. `start-editing-transaction` on the deck, then `perform-editing-operations` on page 1 only: `replace_text` for the talk title, date, speaker name, and role line, plus `update_fill` with the uploaded asset on the editable circular photo element.
+6. Show Mason the thumbnail, then commit the transaction.
+7. If any step cannot complete cleanly, cancel the transaction and give Mason the design's edit URL plus the exact text to place; never leave a half-edited page.
 
 The card layout slots: "Monthly Meetup" heading (fixed), talk title, date ("DD Month YYYY"), time ("8:00 - 9:00pm CST", fixed), "PyTexas Discord Server" (fixed), speaker name, speaker role line, circular headshot, RSVP URL (fixed).
+
+There is no delete-design tool in the MCP; any scratch designs from experiments have to be trashed by Mason in the Canva UI.

--- a/.claude/skills/meetup-update/references/canva-cards.md
+++ b/.claude/skills/meetup-update/references/canva-cards.md
@@ -39,3 +39,6 @@ The workflow, verified end to end on the real deck on 2026-07-22:
 The card layout slots: "Monthly Meetup" heading (fixed), talk title, date ("DD Month YYYY"), time ("8:00 - 9:00pm CST", fixed), "PyTexas Discord Server" (fixed), speaker name, speaker role line, circular headshot, RSVP URL (fixed).
 
 There is no delete-design tool in the MCP; any scratch designs from experiments have to be trashed by Mason in the Canva UI.
+
+Known limitation: the duplicated page inherits the source page's title label (e.g. "June 2026"), and page titles cannot be renamed through the API (confirmed via Canva's help service on 2026-07-22).
+After every card, remind Mason to rename the page title in the editor: hover the page thumbnail, ellipsis, pencil icon next to the page title.

--- a/.claude/skills/meetup-update/references/drive-artifacts.md
+++ b/.claude/skills/meetup-update/references/drive-artifacts.md
@@ -1,0 +1,48 @@
+# Drive Artifacts: Month Folder, Run of Show, Attendance Form
+
+Every meetup gets a folder in Google Drive holding its run of show doc, attendance form, and the response sheets that accumulate around it.
+Create these at setup time; slots that depend on meetup night (roles, announcements, the local meetups table) stay as placeholders until then.
+
+Find everything by title search, never by hardcoded file ID (this repo is public).
+
+## Folder Layout
+
+```text
+<Meetups root>/
+  <YYYY>/                 year folder, e.g. "2026"
+    <YYYY-MM-DD>/         month folder named for the meetup date, e.g. "2026-02-03"
+      Run of Show <YYYY-MM-DD>
+      PyTexas Virtual Meetup Attendance <YYYY-MM-DD>          (Google Form)
+      PyTexas Virtual Meetup Attendance <YYYY-MM-DD> (Responses)
+      Questions for <Speaker>                                  (optional Google Form)
+      Questions for <Speaker> (Responses)
+```
+
+## Creating the Month Folder
+
+1. Search Drive for the year folder (title equals the four-digit year). Its parent is the meetups root.
+2. If the year folder does not exist yet (January), create it there first.
+3. Create the month folder inside it, titled `YYYY-MM-DD` (the meetup date).
+
+## Creating the Run of Show
+
+1. Search Drive for the doc titled "Run of Show Template".
+2. Copy it into the month folder with the title `Run of Show YYYY-MM-DD`.
+3. Fill the slots per `run-of-show.md`, which mirrors the template's structure.
+   Fill what is known at setup time (month, speaker, talk, bio, attendance links); leave roles and announcements as placeholders.
+
+If the Drive template has drifted from `run-of-show.md`, the Drive template wins for structure; update `run-of-show.md` to match and tell Mason.
+
+## Creating the Attendance Form
+
+Google Forms cannot be authored through the Drive MCP, but they can be copied.
+
+1. Search Drive for the form titled "PyTexas Meetup Attendance <DATE>" (it lives in the "Attendance Forms Template" folder).
+2. Copy it into the month folder with the title `PyTexas Virtual Meetup Attendance YYYY-MM-DD`.
+3. Put the copy's full form URL in the run of show under Announcements and Links.
+
+Caveats to flag to Mason every time:
+
+- The copied form's questions come from the template (Name, closest Texas region). Nothing to edit unless the questions changed.
+- The response spreadsheet does not exist until someone opens the form's Responses tab; the "Attendance Answers" link in the run of show stays a placeholder until then.
+- The short `forms.gle` link can only be generated from the form's Send dialog in the browser. The run of show gets the full URL; Mason swaps in the short link if he wants one.

--- a/.claude/skills/meetup-update/references/kassandra-email.md
+++ b/.claude/skills/meetup-update/references/kassandra-email.md
@@ -1,0 +1,35 @@
+# Social Media Assets Email to Kassandra
+
+PROPOSED TEMPLATE: no prior email to Kassandra about social assets exists in Gmail to copy, so Mason has not approved this wording yet.
+On first use, confirm the wording with him, then delete this paragraph.
+
+Kassandra Keeton runs social media promotion.
+Create a Gmail draft (never send) and fill only the `<angle bracket>` slots.
+
+- To: kassandra@pytexas.org
+- Subject: PyTexas Meetup Social Media Assets - <Month> <Year>
+
+```text
+Hey Kassandra,
+
+The <Month> meetup is booked and the promo card is ready. Details for the posts:
+
+* Date: <Weekday>, <Month> <Day> at 8:00 PM Central
+* Talk: <Talk Title>
+* Speaker: <Speaker Name>
+* Card: <Canva design link or exported card link>
+* RSVP: https://pytexas.org/meetup/join
+
+Let me know if you need anything else.
+
+Mason
+
+---
+Mason Egger
+PyTexas Foundation - President
+PyTexas Conference - Conference Chair
+PyTexas Meetup - Organizer
+Python Software Foundation Fellow
+```
+
+If the card is not ready, say so in the draft and link the deck so she can grab it when it lands.

--- a/.claude/skills/meetup-update/references/outreach-email.md
+++ b/.claude/skills/meetup-update/references/outreach-email.md
@@ -1,0 +1,39 @@
+# Speaker Outreach Email Template
+
+The standard email Mason sends to accepted CFP submitters to offer meetup dates.
+Create these as Gmail drafts for Mason to review and send; never send directly.
+
+- To: the speaker's email from the CFP sheet (or their corrected contact email if they gave one)
+- Cc: meetup@pytexas.org
+- Subject: Speak at PyTexas Meetup
+
+Replace `<First Name>` and list only the first-Tuesday dates that are still open (no booked speaker, not yet passed).
+
+```text
+Hey <First Name>,
+
+Thanks for reaching out! We'd love to have you speak at our virtual meetup. Currently we are looking for speakers for the following dates:
+* <Month> <Day>
+* <Month> <Day>
+* <Month> <Day>
+
+Can you select two dates and send me your preference? Then can you make sure you've joined the PyTexas Discord (https://discord.gg/pytexas) and when you do, ping me so I can give you the proper permissions.
+
+Thank you and we look forward to your presentation!
+
+Mason
+
+---
+Mason Egger
+PyTexas Foundation - President
+PyTexas Conference - Conference Chair
+PyTexas Meetup - Organizer
+Python Software Foundation Fellow
+```
+
+Known issue: Gmail rewrites bare URLs in API-created drafts into `google.com/url?q=...` redirect wrappers.
+The wrapped link still redirects correctly but looks mangled.
+Providing an HTML body with an anchor tag does not prevent the rewrite in the stored plaintext, so after drafting, tell Mason to verify the Discord link in the compose window and retype it there if needed.
+
+The speaker's reply names their two preferred dates; Mason picks one and that becomes the booked month.
+Record the outcome by flipping the row's Acked column in the CFP sheet.

--- a/.claude/skills/meetup-update/references/run-of-show.md
+++ b/.claude/skills/meetup-update/references/run-of-show.md
@@ -1,0 +1,78 @@
+# Run of Show Template
+
+The fill-in content for the monthly run of show Google Doc.
+This mirrors the Drive doc "Run of Show Template"; the Drive doc is the structural source of truth.
+Fill only the `<angle bracket>` slots.
+Slots marked TBD stay literal until meetup night.
+
+```text
+PyTexas Virtual Meetup - <Month> <Year>
+
+# Schedule
+
+- 7:30 - Join voice chat in #pre-and-post-meetup-chat
+- 7:55 - Launch Discord stage and event and migrate people from chat to stage
+- 8:00 - Meetup!
+  - Welcome and Announcements
+  - Main Talk - <Speaker Name>
+  - Wrap up and drawing for door prize
+- After - Join voice chat in #pre-and-post-meetup-chat
+
+# Roles
+
+- Host: TBD
+- Moderators: TBD
+- Winner: TBD
+
+# Announcements
+
+- Attendance Survey: <attendance form URL>
+- Door Prize - A tech book up to $50
+- Questions: <questions form URL, or "Just ask in chat tonight">
+- Speak at this very PyTexas Virtual Meetup! The CFP is open at https://www.pytexas.org/meetup/
+- <current announcements: conference dates, ticket sales, grants, and similar>
+
+# Links
+
+- Attendance: <attendance form URL>
+- Attendance Answers: <responses sheet URL, placeholder until the sheet exists>
+
+# Speaker Data
+
+### Talk
+
+#### <Talk Title> - <Speaker Name>
+
+<Full talk description>
+
+### Bio: <Full speaker bio>
+
+# Upcoming Meetups
+
+Pull up https://www.pytexas.org/meetup/local-meetups/ for this.
+
+| Meetup | Date | Location | Area |
+| ------ | ---- | -------- | ---- |
+| TBD    |      |          |      |
+
+If you know of other groups, add them!
+
+## Next month
+
+<Next meetup date and, if booked, speaker and talk>
+
+Useful links
+
+- Meetup CFP: https://forms.gle/a9WrW7wJSkPCCG437
+- PyTexas Foundation Site: https://pytexas.org
+- PyTexas Conference Site: https://www.pytexas.org/<conference year>
+- PyTexas Meetup Site: https://pytexas.org/meetup
+
+Polls
+
+<Optional: one or two audience polls with lettered options>
+
+# Drawing Winner
+```
+
+For July lightning talks, the Speaker Data section is the ordered speaker list instead of a single talk, and the Schedule's Main Talk line reads "Lightning Talks".

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Use `just` for common tasks:
 
 ## Monthly Process
 
+### Automated with Claude Code
+
+The repo ships a Claude Code skill at `.claude/skills/meetup-update/` that runs the full monthly setup.
+Invoke it with `/meetup-update` (or ask to "schedule the monthly meetup").
+
+The skill:
+
+1. Pulls the booked speaker from the "PyTexas Meetup CFP (Responses)" sheet in Google Drive and confirms their locked-in date from the email thread
+2. Archives the held meetup, adds the speaker to `.authors.yml`, updates the homepage, and opens a PR
+3. Creates the month's Drive folder with the run of show doc and attendance form, copied from the templates in Drive
+4. Adds the month's card to the season's "Meetup Banners" deck in Canva
+5. Drafts the date-offer emails to new CFP submitters and the social media email to Kassandra (drafts only, never sends)
+6. Flags what stays manual: the speaker headshot, the Canva page title rename, the Discord event, the Meetup.com event, and the non-network listings
+
+Everything the skill writes comes from the templates in `.claude/skills/meetup-update/references/`.
+Edit those files to change what it produces.
+
+### Manual Process
+
 1. Add the upcoming meetup to the home page by modifying `index.md`
     1. When adding a new presenter, try to use a URL for the photo. Only upload a file if you must, and upload it to `assets/images`
         * **Tip**: A person's GitHub avatar is always available at `https://github.com/USERNAME.png` so use that


### PR DESCRIPTION
## Summary

Folds the lessons from the August/October booking mixup into the skill.

- The CFP responses spreadsheet in Drive is now the primary input source, with notes on the Acked column, test rows, and duplicate submissions.
- The booked date must come from the "Speak at PyTexas Meetup" email thread, never assumed from the next open month.
- New step 0: branch from up-to-date main, since the site can lag several months.
- Documents the July "Summer of Lightning Talks" tradition and its post format.
- Documents holding the PR as a draft when a headshot is missing (strict builds fail on the dangling image reference) or an earlier month is unbooked.
- Adds `references/outreach-email.md` with the standard date-offer email template and the Gmail draft URL-mangling caveat.